### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/coremltools/models/tree_ensemble.py
+++ b/coremltools/models/tree_ensemble.py
@@ -6,7 +6,7 @@
 """
 Tree ensemble builder class to construct CoreML models.
 """
-import collections as _collections
+import collections.abc as _collections
 
 from .. import SPECIFICATION_VERSION as _SPECIFICATION_VERSION
 from ..proto import Model_pb2 as _Model_pb2


### PR DESCRIPTION
As discussed in https://github.com/apple/coremltools/issues/686, importing `Iterable` from collections is no longer supported in Python 3.10.
The solution is to import from collections.abc.